### PR TITLE
fix: correct install instructions to use valid pi package source format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,30 @@ Extensions cover everything from UI polish (custom footer, tool pills, leader-ke
 ## Install
 
 ```bash
-pi install github:tomsej/pi-ext
+pi install git:github.com/tomsej/pi-ext
 ```
 
-Or install individual extensions:
+Or using the full URL:
 
 ```bash
-pi install github:tomsej/pi-ext/extensions/leader-key
+pi install https://github.com/tomsej/pi-ext
 ```
+
+To install the full package but only load specific extensions or skills, use package filtering in your `settings.json`:
+
+```json
+{
+  "packages": [
+    {
+      "source": "git:github.com/tomsej/pi-ext",
+      "extensions": ["extensions/leader-key"],
+      "skills": []
+    }
+  ]
+}
+```
+
+See [Pi Packages docs](https://github.com/badlogic/pi/blob/main/docs/packages.md) for more filtering options.
 
 Requires [Pi](https://github.com/badlogic/pi) v0.37.3+.
 


### PR DESCRIPTION
## Problem

The install instructions in the README use `github:` as a package source prefix:

```bash
pi install github:tomsej/pi-ext
pi install github:tomsej/pi-ext/extensions/leader-key
```

This doesn't work — pi treats `github:...` as a local path, resulting in:

```
Error: Path does not exist: /Users/.../github:tomsej/pi-ext/extensions/leader-key
```

## Fix

Updated to use valid pi package source formats:

- `git:github.com/tomsej/pi-ext` (git shorthand)
- `https://github.com/tomsej/pi-ext` (full URL)

Also replaced the sub-path install example (not supported by pi) with a **package filtering** example showing how to selectively load specific extensions/skills via `settings.json`.

Reference: [Pi Packages docs](https://github.com/badlogic/pi/blob/main/docs/packages.md)