### PR TITLE
fix: pass cwd to leader key model settings

### DIFF
--- a/extensions/leader-key/model-switcher.ts
+++ b/extensions/leader-key/model-switcher.ts
@@ -30,8 +30,8 @@ interface ProviderInfo {
  * Get the set of enabled model identifiers from settings.
  * Returns undefined when there is no filter (all models are enabled).
  */
-function getEnabledModelSet(): Set<string> | undefined {
-	const sm = SettingsManager.create();
+function getEnabledModelSet(ctx: ExtensionContext): Set<string> | undefined {
+	const sm = SettingsManager.create(ctx.cwd);
 	const patterns = sm.getEnabledModels();
 	if (!patterns || patterns.length === 0) return undefined;
 	// enabledModels entries are "provider/modelId" exact strings (or globs, but
@@ -61,7 +61,7 @@ function isModelEnabled(provider: string, modelId: string, enabled: Set<string> 
 }
 
 function getAvailableEnabledModels(ctx: ExtensionContext) {
-	const enabled = getEnabledModelSet();
+	const enabled = getEnabledModelSet(ctx);
 	return ctx.modelRegistry
 		.getAvailable()
 		.filter((m) => isModelEnabled(m.provider, m.id, enabled));


### PR DESCRIPTION
## What happened

Opening the leader key model picker can fail before the provider list renders:

```text
Error: Action failed: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
```

## Repro steps

1. Install/load the `leader-key` extension.
2. Use a recent Pi version where `SettingsManager.create()` requires a `cwd` argument.
3. Open the leader key palette with `Ctrl-X`.
4. Choose `Model`.
5. The action fails while reading enabled model settings.

## Fix

`SettingsManager.create()` was being called without arguments inside the leader key model switcher. That leaves the settings storage without a project path and Node throws when it tries to build `.pi/settings.json` from `undefined`.

This passes `ctx.cwd` through the model filtering helper and calls `SettingsManager.create(ctx.cwd)`, matching Pi's current API.

## Verification

- Reproduced the same `ERR_INVALID_ARG_TYPE` with `SettingsManager.create()` and no cwd.
- Verified `SettingsManager.create(process.cwd())` succeeds.
- Confirmed the same fix locally in my Pi extension install unblocks `Ctrl-X -> Model`.
