### PR TITLE
fix: respect effective thinking level in leader key

### DIFF
--- a/extensions/leader-key/favourite-models.ts
+++ b/extensions/leader-key/favourite-models.ts
@@ -17,7 +17,7 @@ import { matchesKey, Key } from "@mariozechner/pi-tui";
 import { OverlayFrame } from "../shared/overlay.js";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { ALL_THINKING_LEVELS } from "./model-switcher";
+import { ALL_THINKING_LEVELS, getCurrentThinkingLevel, setCurrentThinkingLevel } from "./model-switcher";
 import { THINKING_ROLES } from "../shared/thinking-colors.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -78,7 +78,7 @@ export async function runFavouriteModels(pi: ExtensionAPI, ctx: ExtensionContext
 	}
 
 	const currentModel = ctx.model;
-	const currentThinking = pi.getThinkingLevel();
+	const currentThinking = getCurrentThinkingLevel(pi);
 
 	// Build per-entry thinking indices
 	const thinkingIndices: number[] = favourites.map((fav) => {
@@ -213,7 +213,7 @@ export async function runFavouriteModels(pi: ExtensionAPI, ctx: ExtensionContext
 		ctx.ui.notify(`No API key available for ${selected.fav.provider}/${selected.fav.model}`, "warning");
 		return;
 	}
-	pi.setThinkingLevel(selected.thinking);
+	setCurrentThinkingLevel(pi, selected.thinking);
 
 	ctx.ui.notify(
 		`Switched to ${selected.fav.label} (thinking: ${selected.thinking})`,

--- a/extensions/leader-key/model-switcher.ts
+++ b/extensions/leader-key/model-switcher.ts
@@ -16,6 +16,27 @@ import { fuzzyFilter, Key, matchesKey } from "@mariozechner/pi-tui";
 import { OverlayFrame } from "../shared/overlay.js";
 
 export const ALL_THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
+const GET_EFFECTIVE_THINKING_EVENT = "model-profiles:get-effective-thinking";
+const SET_THINKING_OVERRIDE_EVENT = "model-profiles:set-thinking-override";
+
+function normalizeThinkingLevel(value: unknown): ThinkingLevel | undefined {
+	return typeof value === "string" && (ALL_THINKING_LEVELS as string[]).includes(value)
+		? value as ThinkingLevel
+		: undefined;
+}
+
+export function getCurrentThinkingLevel(pi: ExtensionAPI): ThinkingLevel {
+	const request = {} as { result?: { level?: unknown } };
+	pi.events.emit(GET_EFFECTIVE_THINKING_EVENT, request);
+	return normalizeThinkingLevel(request.result?.level) ?? pi.getThinkingLevel();
+}
+
+export function setCurrentThinkingLevel(pi: ExtensionAPI, level: ThinkingLevel): void {
+	const request = { level, handled: false } as { level: ThinkingLevel; handled?: boolean };
+	pi.events.emit(SET_THINKING_OVERRIDE_EVENT, request);
+	if (request.handled) return;
+	pi.setThinkingLevel(level);
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers — only enabled & available providers & models
@@ -323,10 +344,10 @@ export async function runModelSwitcher(pi: ExtensionAPI, ctx: ExtensionContext):
 	}
 
 	const supportsReasoning = selectedModel.reasoning;
-	let selectedThinking: ThinkingLevel = pi.getThinkingLevel();
+	let selectedThinking: ThinkingLevel = getCurrentThinkingLevel(pi);
 
 	if (supportsReasoning) {
-		const currentThinking = pi.getThinkingLevel();
+		const currentThinking = getCurrentThinkingLevel(pi);
 
 		const thinkingItems: SearchableItem[] = ALL_THINKING_LEVELS.map((level) => {
 			const isCurrent = level === currentThinking;
@@ -356,7 +377,7 @@ export async function runModelSwitcher(pi: ExtensionAPI, ctx: ExtensionContext):
 	}
 
 	if (supportsReasoning) {
-		pi.setThinkingLevel(selectedThinking);
+		setCurrentThinkingLevel(pi, selectedThinking);
 	}
 
 	ctx.ui.notify(
@@ -391,7 +412,7 @@ export function getThinkingDescription(level: ThinkingLevel): string {
 export async function runThinkingPicker(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
 	if (!ctx.hasUI) return;
 
-	const currentThinking = pi.getThinkingLevel();
+	const currentThinking = getCurrentThinkingLevel(pi);
 
 	const thinkingItems: SearchableItem[] = ALL_THINKING_LEVELS.map((level) => {
 		const isCurrent = level === currentThinking;
@@ -410,6 +431,6 @@ export async function runThinkingPicker(pi: ExtensionAPI, ctx: ExtensionContext)
 
 	if (!choice) return;
 
-	pi.setThinkingLevel(choice);
+	setCurrentThinkingLevel(pi, choice);
 	ctx.ui.notify(`Thinking: ${choice}`, "info");
 }


### PR DESCRIPTION
## Summary
- add a small helper around the leader-key thinking getter/setter
- let other Pi extensions provide an effective thinking level via event bus
- use the helper in model switching, favourite models, and the thinking picker

## Why
`pi.getThinkingLevel()` returns the session-level thinking value. Extensions that expose virtual/profile-backed models can have a different effective thinking policy for the active selection. In that case the leader-key thinking picker can highlight the wrong current level and write to the wrong state.

This remains backwards-compatible: if no extension responds to the events, leader-key keeps using `pi.getThinkingLevel()` / `pi.setThinkingLevel()` as before.

## Verify
- `bun -e "await import('./extensions/leader-key/model-switcher.ts'); await import('./extensions/leader-key/favourite-models.ts'); console.log('ok')"`
