### PR TITLE
feat(superconductor): add Superconductor integration extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Three-mode permission system: `yolo` (everything allowed), `safe` (rule-based ch
 
 Native integration with [cmux](https://github.com/badlogic/cmux). Context-aware notifications via the cmux socket API, sidebar status pills (model, state, thinking, tokens), and custom tools for the model (browser, workspace, notify). Silent no-op when not running inside cmux.
 
+### [Superconductor](extensions/superconductor/)
+
+Native integration with [Superconductor](https://superconductor.dev) via the `sc` CLI. Footer pill with the Superconductor-owned target branch and diff size, a `superconductor_worktree` tool for the model (status, diff, target branch, list/create worktrees), and commands (`/sc-fork`, `/sc-worktree`). Silent no-op when not running inside Superconductor.
+
 ### [Ask User Question](extensions/ask-user-question/)
 
 Registers an `ask_user_question` tool the model uses to ask 1–4 structured clarifying questions (with 2–4 options each) instead of asking in plain text. Interactive UI with optional multi-select and short header labels for a tab bar.

--- a/extensions/superconductor/README.md
+++ b/extensions/superconductor/README.md
@@ -1,0 +1,52 @@
+# Superconductor
+
+Native [Superconductor](https://superconductor.dev) integration for pi.
+
+Superconductor launches pi inside managed git worktrees and terminal sessions, and exposes its state through the `sc` CLI (backed by a local API socket). This extension surfaces that integration directly inside pi so the agent — and you — can work with Superconductor without leaving the session.
+
+Inspired by the [cmux extension](../cmux/) and projects like [pi-cmux](https://github.com/javiermolinar/pi-cmux). Where cmux speaks a raw Unix-socket protocol, Superconductor is driven entirely through the `sc` CLI, so this extension shells out to `sc ... --json` and parses the structured envelope.
+
+If pi is not running inside Superconductor, the extension is a silent no-op.
+
+## What you get
+
+### Status pill
+
+A footer status pill shows the Superconductor-owned **target branch** and the current diff size:
+
+```
+SC →main · 6f +639 -0
+```
+
+It refreshes on session start and after each agent run. This is additive — it never overwrites the Superconductor tab title. Set `PI_SC_TAB_TITLE=1` to also drive the tab title with a running/idle indicator.
+
+### Tools for the model
+
+| Tool | Actions |
+|------|---------|
+| `superconductor_worktree` | `status`, `diff_summary`, `set_target_branch`, `rename_branch`, `list_worktrees`, `create` |
+
+- **Worktree** lets the model read the authoritative target/base branch (it is Superconductor-owned — never inferred from git defaults), inspect the diff, list git worktrees, and **create new worktrees**.
+
+  > **Creating worktrees.** Superconductor's local API (v17) exposes no command to create a managed worktree — SC builds those inside the app. So `create` (and the `/sc-worktree` command) fall back to **raw `git worktree add`** against the root repo (`SUPERCONDUCTOR_ROOT_PATH`), branching off `base` (default `main`). The result is a real git worktree on disk; with `open_in_sc` (the command always tries) it is surfaced via `sc workspace open`, but it is **not** registered as a Superconductor-managed task.
+
+### Commands
+
+- `/sc-fork [prompt]` — fork the current session into a new session file and open a fresh Superconductor terminal split. Superconductor terminal panes have no documented "send text" RPC, so the command opens the split and hands you a ready-to-paste `pi --session <file>` command.
+- `/sc-worktree <branch> [base]` — create a git worktree off `base` (default `main`) on `branch`, then open it in Superconductor via `sc workspace open`. See the worktree-creation caveat above.
+
+## Configuration
+
+| Env var | Effect |
+|---------|--------|
+| `PI_SC_DISABLE=1` | Disable the extension entirely |
+| `PI_SC_TAB_TITLE=1` | Drive the Superconductor tab title with running/idle state |
+| `PI_SC_VERBOSE=1` | Log every `sc` invocation to stderr |
+| `SUPERCONDUCTOR_SC_BIN` | Override the `sc` binary path (default: `sc` on PATH) |
+
+Detection uses `SUPERCONDUCTOR_MANAGED_AGENT=1` or the presence of `SUPERCONDUCTOR_LOCAL_API_SOCKET`.
+
+## Notes
+
+- All `sc` calls run with the worktree (`SUPERCONDUCTOR_WORKTREE_PATH`) as the working directory.
+- `sc` envelopes come in two shapes: most commands wrap the payload in `response`, a few put it at the top level. Errors arrive as `{ "kind": "cli_error", "error": { "code", "message" } }`. The client normalizes all three.

--- a/extensions/superconductor/commands.ts
+++ b/extensions/superconductor/commands.ts
@@ -1,0 +1,104 @@
+/**
+ * Superconductor slash commands.
+ *
+ * /sc-fork [prompt]  — fork this pi session and open a new Superconductor
+ *                      terminal split. Superconductor terminal panes have no
+ *                      documented "send text" RPC, so we open the split and
+ *                      hand the user a ready-to-paste `pi --session` command.
+ *
+ * /sc-worktree NAME [base] — create a git worktree off base (default main)
+ *                      and open it in Superconductor via `sc workspace open`.
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { existsSync, promises as fs } from "node:fs";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import type { ScClient } from "./sc-client.js";
+import { createWorktree } from "./git.js";
+
+function shellQuote(value: string): string {
+	if (value.length === 0) return "''";
+	return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function piInvocation(): string[] {
+	const script = process.argv[1];
+	if (script && existsSync(script)) return [process.execPath, script];
+	const name = path.basename(process.execPath).toLowerCase();
+	return /^(node|bun)(\.exe)?$/.test(name) ? ["pi"] : [process.execPath];
+}
+
+async function forkSessionFile(ctx: ExtensionCommandContext): Promise<string | undefined> {
+	const sessionFile = ctx.sessionManager.getSessionFile();
+	if (!sessionFile) return undefined;
+
+	const dir = path.dirname(sessionFile);
+	const branch = ctx.sessionManager.getBranch();
+	const header = ctx.sessionManager.getHeader();
+	const ts = new Date().toISOString();
+	const id = randomUUID();
+	const newFile = path.join(dir, `${ts.replace(/[:.]/g, "-")}_${id}.jsonl`);
+
+	const newHeader = {
+		type: "session",
+		version: header?.version ?? 3,
+		id,
+		timestamp: ts,
+		cwd: header?.cwd ?? ctx.cwd,
+		parentSession: sessionFile,
+	};
+	const lines = [JSON.stringify(newHeader), ...branch.map((e) => JSON.stringify(e))].join("\n") + "\n";
+	await fs.mkdir(dir, { recursive: true });
+	await fs.writeFile(newFile, lines, "utf8");
+	return newFile;
+}
+
+export function wireCommands(pi: ExtensionAPI, client: ScClient): void {
+	pi.registerCommand("sc-fork", {
+		description: "Fork this session and open a new Superconductor terminal split. Usage: /sc-fork [prompt]",
+		handler: async (args, ctx) => {
+			const prompt = args.trim();
+			const forked = await forkSessionFile(ctx);
+
+			const split = await client.tabSplit("right", "terminal");
+			if (!split.ok) {
+				ctx.ui.notify(`Could not open split: ${split.error?.message}`, "error");
+				if (forked) ctx.ui.notify(`Forked session saved: ${forked}`, "info");
+				return;
+			}
+
+			if (!forked) {
+				ctx.ui.notify("Opened a terminal split (no persisted session to fork).", "warning");
+				return;
+			}
+
+			const parts = [...piInvocation(), "--session", forked];
+			if (prompt) parts.push("--", prompt);
+			const cmd = parts.map(shellQuote).join(" ");
+			ctx.ui.notify(`Terminal split opened. Run in it:\n${cmd}`, "info");
+		},
+	});
+
+	pi.registerCommand("sc-worktree", {
+		description: "Create a new git worktree off a base branch. Usage: /sc-worktree <branch> [base] (base default: main)",
+		handler: async (args, ctx) => {
+			const [branch, base] = args.trim().split(/\s+/);
+			if (!branch) {
+				ctx.ui.notify("Usage: /sc-worktree <branch> [base]", "warning");
+				return;
+			}
+			const res = await createWorktree({ branch, base });
+			if (!res.ok) {
+				ctx.ui.notify(`Worktree create failed: ${res.error}`, "error");
+				return;
+			}
+			const opened = await client.workspaceOpen(res.path);
+			const tail = opened.ok ? " (opened in SC)" : ` (open in SC failed: ${opened.error?.message})`;
+			ctx.ui.notify(
+				`Worktree ready: ${res.path}\nbranch ${res.branch} ← ${res.base}${tail}`,
+				opened.ok ? "info" : "warning",
+			);
+		},
+	});
+}

--- a/extensions/superconductor/git.ts
+++ b/extensions/superconductor/git.ts
@@ -1,0 +1,145 @@
+/**
+ * Git worktree helper.
+ *
+ * Superconductor's local API (v17) does NOT expose a "create worktree"
+ * command — its worktrees are created inside the app process and never
+ * surfaced over the `sc` CLI / socket. But SC worktrees are ultimately just
+ * `git worktree` checkouts, so we create one with raw git and (optionally)
+ * hand it to SC via `sc workspace open`.
+ *
+ * Everything here shells out to `git`. No throws on failure — we return a
+ * structured result the tool layer can present.
+ */
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+
+export interface GitResult {
+	ok: boolean;
+	stdout: string;
+	stderr: string;
+	code: number | null;
+}
+
+function git(repo: string, args: string[], timeout = 30_000): Promise<GitResult> {
+	return new Promise((resolve) => {
+		execFile("git", ["-C", repo, ...args], { timeout, maxBuffer: 8 * 1024 * 1024 }, (err, stdout, stderr) => {
+			const code = err ? ((err as NodeJS.ErrnoException).code === "ENOENT" ? null : (err as any).code ?? 1) : 0;
+			resolve({
+				ok: !err,
+				stdout: (stdout || "").trim(),
+				stderr: (stderr || "").trim(),
+				code: typeof code === "number" ? code : null,
+			});
+		});
+	});
+}
+
+/** The primary checkout for the project (the repo SC branched this worktree from). */
+export function rootRepo(): string | undefined {
+	return process.env.SUPERCONDUCTOR_ROOT_PATH || undefined;
+}
+
+function sanitizeBranchForPath(branch: string): string {
+	return branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "worktree";
+}
+
+async function branchExists(repo: string, branch: string): Promise<boolean> {
+	const res = await git(repo, ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`]);
+	return res.ok && res.stdout.length > 0;
+}
+
+export interface CreateWorktreeOptions {
+	/** New (or existing) branch name to check out in the worktree. */
+	branch: string;
+	/** Base ref to branch from when creating a new branch. Default: "main". */
+	base?: string;
+	/** Destination path. Default: sibling of the root repo named "<repo>-<branch>". */
+	dest?: string;
+	/** Override the root repo. Default: SUPERCONDUCTOR_ROOT_PATH. */
+	repo?: string;
+}
+
+export interface CreateWorktreeResult {
+	ok: boolean;
+	/** Absolute path of the created worktree (set even on some failures for context). */
+	path: string;
+	branch: string;
+	base: string;
+	/** Whether a new branch was created (vs. checking out an existing one). */
+	createdBranch: boolean;
+	error?: string;
+}
+
+/**
+ * Create a git worktree off `base` (default main) checked out on `branch`.
+ *
+ * - If the branch already exists, it is checked out (base is ignored).
+ * - If it does not exist, it is created from `base`.
+ */
+export async function createWorktree(opts: CreateWorktreeOptions): Promise<CreateWorktreeResult> {
+	const repo = opts.repo || rootRepo();
+	const base = opts.base || "main";
+	const branch = opts.branch;
+
+	const fail = (path: string, createdBranch: boolean, error: string): CreateWorktreeResult => ({
+		ok: false,
+		path,
+		branch,
+		base,
+		createdBranch,
+		error,
+	});
+
+	if (!repo) return fail("", false, "no root repo (SUPERCONDUCTOR_ROOT_PATH unset); pass repo explicitly");
+	if (!existsSync(repo)) return fail("", false, `root repo does not exist: ${repo}`);
+	if (!branch || !branch.trim()) return fail("", false, "branch name is required");
+
+	// Resolve destination: explicit, else sibling of the repo.
+	const dest = opts.dest
+		? path.resolve(opts.dest)
+		: path.join(path.dirname(repo), `${path.basename(repo)}-${sanitizeBranchForPath(branch)}`);
+
+	if (existsSync(dest)) return fail(dest, false, `destination already exists: ${dest}`);
+
+	const exists = await branchExists(repo, branch);
+
+	// `git worktree add <dest> -b <branch> <base>` for a new branch,
+	// or `git worktree add <dest> <branch>` to attach an existing one.
+	const args = exists
+		? ["worktree", "add", dest, branch]
+		: ["worktree", "add", dest, "-b", branch, base];
+
+	const res = await git(repo, args);
+	if (!res.ok) {
+		return fail(dest, !exists, res.stderr || res.stdout || `git exited with code ${res.code}`);
+	}
+
+	return { ok: true, path: dest, branch, base, createdBranch: !exists };
+}
+
+/** List existing git worktrees of the root repo (porcelain, parsed). */
+export async function listWorktrees(repo?: string): Promise<
+	{ ok: boolean; worktrees: Array<{ path: string; branch?: string; head?: string }>; error?: string }
+> {
+	const r = repo || rootRepo();
+	if (!r) return { ok: false, worktrees: [], error: "no root repo (SUPERCONDUCTOR_ROOT_PATH unset)" };
+	const res = await git(r, ["worktree", "list", "--porcelain"]);
+	if (!res.ok) return { ok: false, worktrees: [], error: res.stderr || res.stdout };
+
+	const worktrees: Array<{ path: string; branch?: string; head?: string }> = [];
+	let cur: { path: string; branch?: string; head?: string } | null = null;
+	for (const line of res.stdout.split("\n")) {
+		if (line.startsWith("worktree ")) {
+			if (cur) worktrees.push(cur);
+			cur = { path: line.slice("worktree ".length) };
+		} else if (line.startsWith("HEAD ") && cur) {
+			cur.head = line.slice("HEAD ".length);
+		} else if (line.startsWith("branch ") && cur) {
+			cur.branch = line.slice("branch ".length).replace(/^refs\/heads\//, "");
+		}
+	}
+	if (cur) worktrees.push(cur);
+	return { ok: true, worktrees };
+}

--- a/extensions/superconductor/index.ts
+++ b/extensions/superconductor/index.ts
@@ -1,0 +1,30 @@
+/**
+ * pi-superconductor: native Superconductor integration for pi.
+ *
+ * Superconductor launches pi inside managed worktrees + terminal sessions and
+ * exposes everything through the `sc` CLI (backed by the local API socket).
+ * This extension surfaces that to pi:
+ *
+ *   - Status:   footer pill with target branch + diff size (+ optional tab title)
+ *   - Tools:    superconductor_worktree (status/diff/target branch + create worktree)
+ *   - Commands: /sc-fork (fork into a new terminal split), /sc-worktree (new worktree)
+ *
+ * Gracefully degrades: if not running inside Superconductor, it is a no-op.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { ScClient } from "./sc-client.js";
+import { wireStatus } from "./status.js";
+import { wireTools } from "./tools.js";
+import { wireCommands } from "./commands.js";
+
+export default function (pi: ExtensionAPI) {
+	const client = new ScClient();
+
+	// Not inside Superconductor — do nothing.
+	if (!client.available) return;
+
+	wireStatus(pi, client);
+	wireTools(pi, client);
+	wireCommands(pi, client);
+}

--- a/extensions/superconductor/sc-client.ts
+++ b/extensions/superconductor/sc-client.ts
@@ -1,0 +1,176 @@
+/**
+ * Superconductor CLI client — thin wrapper around the `sc` binary.
+ *
+ * Unlike cmux (which speaks a raw Unix-socket protocol), Superconductor
+ * exposes everything through the `sc` CLI, which in turn talks to the
+ * local API socket (SUPERCONDUCTOR_LOCAL_API_SOCKET). We shell out to `sc`
+ * with `--json` / `--output json` and parse the structured envelope.
+ *
+ * Response envelope shapes observed in the wild:
+ *   { "kind": "worktree_status", "response": { ... } }        // most commands
+ *   { "kind": "providers", "providers": [ ... ] }              // some commands put data at top level
+ *   { "kind": "cli_error", "error": { "code", "message" } }    // any failure
+ *
+ * Gracefully degrades: if not running inside Superconductor (or `sc` is
+ * missing), `available` is false and every call resolves to a failed
+ * ScResult. No throws, no noise.
+ */
+
+import { execFile } from "node:child_process";
+
+export interface ScError {
+	code: string;
+	message: string;
+}
+
+export interface ScResult<T = any> {
+	/** True when the command ran and `sc` did not return a cli_error. */
+	ok: boolean;
+	/** The "kind" discriminator from the envelope, or "exec_error". */
+	kind: string;
+	/** The payload: `response` field when present, otherwise the whole envelope. */
+	response: T | null;
+	/** Populated when ok is false. */
+	error: ScError | null;
+	/** Full parsed envelope, for callers that need top-level fields. */
+	raw: any;
+}
+
+function fail(kind: string, error: ScError): ScResult {
+	return { ok: false, kind, response: null, error, raw: null };
+}
+
+export class ScClient {
+	private readonly bin: string;
+	private readonly worktree: string | undefined;
+	private readonly verbose: boolean;
+
+	constructor() {
+		this.bin = process.env.SUPERCONDUCTOR_SC_BIN || "sc";
+		this.worktree = process.env.SUPERCONDUCTOR_WORKTREE_PATH;
+		this.verbose = process.env.PI_SC_VERBOSE === "1";
+	}
+
+	/** True if we appear to be running as a Superconductor-managed agent. */
+	get available(): boolean {
+		if (process.env.PI_SC_DISABLE === "1") return false;
+		return (
+			process.env.SUPERCONDUCTOR_MANAGED_AGENT === "1" ||
+			!!process.env.SUPERCONDUCTOR_LOCAL_API_SOCKET
+		);
+	}
+
+	/**
+	 * Run an `sc` subcommand. `args` should NOT include the json flag — the
+	 * caller picks `--json` or `--output json` via `outputFlag`, because the
+	 * CLI is inconsistent across command families.
+	 */
+	async run(
+		args: string[],
+		opts: { stdin?: string; timeout?: number; outputFlag?: "json" | "output-json" | "none" } = {},
+	): Promise<ScResult> {
+		if (!this.available) {
+			return fail("unavailable", { code: "unavailable", message: "Superconductor is not available" });
+		}
+
+		const flagArgs =
+			opts.outputFlag === "output-json"
+				? ["--output", "json"]
+				: opts.outputFlag === "none"
+					? []
+					: ["--json"];
+		const fullArgs = [...args, ...flagArgs];
+		const timeout = opts.timeout ?? 10_000;
+
+		if (this.verbose) console.error("[pi-sc] ->", this.bin, fullArgs.join(" "));
+
+		return new Promise<ScResult>((resolve) => {
+			const child = execFile(
+				this.bin,
+				fullArgs,
+				{ timeout, cwd: this.worktree, maxBuffer: 8 * 1024 * 1024 },
+				(err, stdout, stderr) => {
+					const out = (stdout || "").trim();
+
+					// Try to parse JSON first — even on a non-zero exit, `sc` usually
+					// prints a structured cli_error envelope to stdout.
+					const parsed = this.parse(out);
+					if (parsed) {
+						if (this.verbose) console.error("[pi-sc] <-", parsed.kind, parsed.ok ? "ok" : parsed.error?.code);
+						return resolve(parsed);
+					}
+
+					if (err) {
+						const msg = (stderr || "").trim() || err.message;
+						const code = (err as NodeJS.ErrnoException).code === "ENOENT" ? "sc_not_found" : "exec_error";
+						return resolve(fail("exec_error", { code, message: msg }));
+					}
+
+					resolve(fail("parse_error", { code: "parse_error", message: out || "empty output" }));
+				},
+			);
+
+			if (opts.stdin !== undefined) {
+				child.stdin?.write(opts.stdin);
+				child.stdin?.end();
+			}
+		});
+	}
+
+	/** Parse a single-line JSON envelope into an ScResult, or null if not JSON. */
+	private parse(out: string): ScResult | null {
+		if (!out) return null;
+		// `sc` may emit several JSON lines (e.g. watch). We only want the last
+		// complete object for one-shot commands.
+		const line = out.split("\n").reverse().find((l) => l.trim().startsWith("{"));
+		if (!line) return null;
+		let obj: any;
+		try {
+			obj = JSON.parse(line);
+		} catch {
+			return null;
+		}
+		const kind = typeof obj.kind === "string" ? obj.kind : "unknown";
+		if (kind === "cli_error" || obj.error) {
+			const e = obj.error ?? {};
+			return fail(kind, { code: e.code ?? "error", message: e.message ?? "unknown error" });
+		}
+		const { kind: _k, response, ...rest } = obj;
+		return { ok: true, kind, response: response ?? rest, error: null, raw: obj };
+	}
+
+	// ── Worktree ──────────────────────────────────────────────────────────
+
+	worktreeStatus(): Promise<ScResult> {
+		return this.run(["worktree", "status"]);
+	}
+
+	diffSummary(file?: string): Promise<ScResult> {
+		return this.run(["worktree", "diff-summary", ...(file ? ["--file", file] : [])]);
+	}
+
+	setTargetBranch(branch: string): Promise<ScResult> {
+		return this.run(["worktree", "set-target-branch", branch]);
+	}
+
+	renameBranch(name: string): Promise<ScResult> {
+		return this.run(["worktree", "rename-branch", name]);
+	}
+
+	// ── Workspace ─────────────────────────────────────────────────────────
+
+	/** Open a directory as a Superconductor workspace (project). */
+	workspaceOpen(path: string, activate = true): Promise<ScResult> {
+		return this.run(["workspace", "open", path, ...(activate ? ["--activate"] : [])]);
+	}
+
+	// ── Tab ───────────────────────────────────────────────────────────────
+
+	tabTitle(title: string): Promise<ScResult> {
+		return this.run(["tab", "title", title]);
+	}
+
+	tabSplit(direction: "up" | "down" | "left" | "right", ui: "auto" | "chat" | "terminal" = "terminal"): Promise<ScResult> {
+		return this.run(["tab", "split", "--direction", direction, "--ui", ui]);
+	}
+}

--- a/extensions/superconductor/status.ts
+++ b/extensions/superconductor/status.ts
@@ -1,0 +1,60 @@
+/**
+ * Superconductor status surface.
+ *
+ * Two non-destructive signals:
+ *   1. A pi footer status pill ("SC →main · +12 -3") showing the target
+ *      branch and current diff size. Refreshed on session start and after
+ *      each agent run. This is purely additive — it does not touch the
+ *      Superconductor tab title.
+ *   2. Optional tab-title state (opt-in via PI_SC_TAB_TITLE=1). Because the
+ *      tab title is user-facing and shared, we only drive it when asked.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ScClient } from "./sc-client.js";
+
+const STATUS_KEY = "superconductor";
+
+interface WorktreeStatus {
+	branch?: string;
+	target_branch?: string;
+	files_changed?: number;
+	insertions?: number;
+	deletions?: number;
+}
+
+export function wireStatus(pi: ExtensionAPI, client: ScClient): void {
+	const driveTabTitle = process.env.PI_SC_TAB_TITLE === "1";
+	let baseLabel = "SC";
+
+	async function refreshFooter(ctx: { ui: { setStatus(key: string, value?: string): void; hasUI?: boolean } }): Promise<void> {
+		const res = await client.worktreeStatus();
+		if (!res.ok) return;
+		const s = res.response as WorktreeStatus;
+		const target = s.target_branch ? `→${s.target_branch}` : "";
+		const diff =
+			s.files_changed && s.files_changed > 0
+				? ` · ${s.files_changed}f +${s.insertions ?? 0} -${s.deletions ?? 0}`
+				: "";
+		baseLabel = `SC ${target}`.trim();
+		ctx.ui.setStatus(STATUS_KEY, `${baseLabel}${diff}`);
+	}
+
+	pi.on("session_start", async (_event, ctx) => {
+		await refreshFooter(ctx as any);
+		if (driveTabTitle) await client.tabTitle("● pi idle");
+	});
+
+	pi.on("agent_start", async () => {
+		if (driveTabTitle) await client.tabTitle("⚡ pi running");
+	});
+
+	pi.on("agent_end", async (_event, ctx) => {
+		await refreshFooter(ctx as any);
+		if (driveTabTitle) await client.tabTitle("✓ pi idle");
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		(ctx as any)?.ui?.setStatus?.(STATUS_KEY, undefined);
+	});
+}

--- a/extensions/superconductor/tools.ts
+++ b/extensions/superconductor/tools.ts
@@ -1,0 +1,129 @@
+/**
+ * Custom tools exposing Superconductor to the LLM.
+ *
+ * - superconductor_worktree: read worktree status / diff, change target branch,
+ *   list git worktrees, and create new ones (raw git, since SC has no create API).
+ *
+ * The tool surfaces `sc` cli_error envelopes verbatim so the model can react.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { truncateTail } from "@mariozechner/pi-coding-agent";
+import { StringEnum } from "@mariozechner/pi-ai";
+import { Type } from "@sinclair/typebox";
+import type { ScClient, ScResult } from "./sc-client.js";
+import { createWorktree, listWorktrees, rootRepo } from "./git.js";
+
+type ToolResult = { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> };
+
+function text(s: string, details: Record<string, unknown> = {}): ToolResult {
+	return { content: [{ type: "text", text: s }], details };
+}
+
+/** Render an ScResult as a tool result. Throws on failure so pi flags isError. */
+function present(res: ScResult, emptyNote = "ok"): ToolResult {
+	if (!res.ok) {
+		throw new Error(`sc error [${res.error?.code}]: ${res.error?.message}`);
+	}
+	const payload = res.response;
+	if (payload === null || payload === undefined) return text(emptyNote);
+	const json = typeof payload === "string" ? payload : JSON.stringify(payload, null, 2);
+	const truncated = truncateTail(json, { maxBytes: 50_000, maxLines: 2000 });
+	return text(truncated.content, { kind: res.kind });
+}
+
+export function wireTools(pi: ExtensionAPI, client: ScClient): void {
+	// ── superconductor_worktree ─────────────────────────────────────────────
+	pi.registerTool({
+		name: "superconductor_worktree",
+		label: "SC Worktree",
+		description: [
+			"Inspect and control the Superconductor worktree.",
+			"",
+			"status          — branch, target/base branch, files changed, +/- lines",
+			"diff_summary    — per-file change summary (optional file filter)",
+			"set_target_branch — change the review/merge target branch",
+			"rename_branch   — rename the current worktree branch",
+			"list_worktrees  — list git worktrees of the root repo",
+			"create          — create a NEW git worktree off a base branch (default main),",
+			"                  checked out on a new/existing branch; optionally open it in SC.",
+			"",
+			"The target/base branch is Superconductor-owned. Use status to read it; never infer from git defaults.",
+			"Note: SC has no API to create a managed worktree, so create uses raw git. The new worktree",
+			"is a real git checkout; with open_in_sc it is surfaced via `sc workspace open` but is not a",
+			"Superconductor-managed task.",
+		].join("\n"),
+		promptSnippet: "Read Superconductor worktree status, diff, target branch; create new git worktrees off main.",
+		promptGuidelines: [
+			"Use superconductor_worktree status to read the authoritative target/base branch instead of guessing from git.",
+			"To branch off main into a fresh worktree, use action=create with a branch name (base defaults to main).",
+		],
+		parameters: Type.Object({
+			action: StringEnum([
+				"status",
+				"diff_summary",
+				"set_target_branch",
+				"rename_branch",
+				"list_worktrees",
+				"create",
+			] as const),
+			file: Type.Optional(Type.String({ description: "For diff_summary: limit to a single file path" })),
+			branch: Type.Optional(
+				Type.String({ description: "For set_target_branch: new target branch. For create: new/existing branch to check out." }),
+			),
+			name: Type.Optional(Type.String({ description: "For rename_branch: the new branch name" })),
+			base: Type.Optional(Type.String({ description: "For create: base ref to branch from (default: main)" })),
+			path: Type.Optional(
+				Type.String({ description: "For create: destination dir (default: sibling of root repo, '<repo>-<branch>')" }),
+			),
+			open_in_sc: Type.Optional(
+				Type.Boolean({ description: "For create: open the new worktree in Superconductor via `sc workspace open`" }),
+			),
+		}),
+		async execute(_id, params): Promise<ToolResult> {
+			switch (params.action) {
+				case "status":
+					return present(await client.worktreeStatus());
+				case "diff_summary":
+					return present(await client.diffSummary(params.file));
+				case "set_target_branch":
+					if (!params.branch) throw new Error("branch is required for set_target_branch");
+					return present(await client.setTargetBranch(params.branch), "target branch updated");
+				case "rename_branch":
+					if (!params.name) throw new Error("name is required for rename_branch");
+					return present(await client.renameBranch(params.name), "branch renamed");
+				case "list_worktrees": {
+					const res = await listWorktrees();
+					if (!res.ok) throw new Error(`git error: ${res.error}`);
+					return text(JSON.stringify({ root: rootRepo(), worktrees: res.worktrees }, null, 2));
+				}
+				case "create": {
+					if (!params.branch) throw new Error("branch is required for create");
+					const created = await createWorktree({
+						branch: params.branch,
+						base: params.base,
+						dest: params.path,
+					});
+					if (!created.ok) throw new Error(`worktree create failed: ${created.error}`);
+					let opened: ScResult | null = null;
+					if (params.open_in_sc) opened = await client.workspaceOpen(created.path);
+					return text(
+						JSON.stringify(
+							{
+								path: created.path,
+								branch: created.branch,
+								base: created.base,
+								created_branch: created.createdBranch,
+								opened_in_sc: opened ? opened.ok : false,
+								open_error: opened && !opened.ok ? opened.error?.message : undefined,
+							},
+							null,
+							2,
+						),
+						{ kind: "worktree_created" },
+					);
+				}
+			}
+		},
+	});
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "./extensions/ask-user-question/index.ts",
       "./extensions/tool-pills/index.ts",
       "./extensions/cmux/index.ts",
+      "./extensions/superconductor/index.ts",
       "./extensions/session-snap/index.ts",
       "./extensions/pi-telescope/index.ts",
       "./extensions/handoff/index.ts",


### PR DESCRIPTION
Native Superconductor integration via the `sc` CLI.

- Footer status pill: target branch + diff size
- `superconductor_worktree` tool: status, diff_summary, set_target_branch, rename_branch, list_worktrees, create
- Commands: `/sc-fork`, `/sc-worktree`
- Worktree `create` uses raw git (SC local API v17 has no create-worktree command); optional `sc workspace open`
- Silent no-op when not running inside Superconductor